### PR TITLE
Create tempfile with markdown extension

### DIFF
--- a/lib/open-in-editor-message-dialog.js
+++ b/lib/open-in-editor-message-dialog.js
@@ -51,7 +51,7 @@ export default class OpenInEditorMessageDialog extends React.Component {
     // console.log('Open Editor', editorPath, editorArgs)
 
     // Create temporary file
-    tmp.file((err, path, fd, cleanupCallback) => {
+    tmp.file({ postfix: ".md" }, (err, path, fd, cleanupCallback) => {
       if (err) {
         inkdrop.notifications.addError(
           `Could not create temporary file.\n${err}`


### PR DESCRIPTION
By creating the temp file with a `.md` extension, the external editor's syntax highlighting, etc., can take effect.

It could be neat to allow the user to specify options here, but since Markdown is at the core of Inkdrop, it doesn't seem like there's a reason not to treat the temp files as Markdown.